### PR TITLE
Change to for disabled clients

### DIFF
--- a/vpnrpt.py
+++ b/vpnrpt.py
@@ -83,7 +83,7 @@ def stopPeriodTimer():
 def getClientList():
     logging.debug('--> getClientList')
     rawClients = os.popen("pivpn -l").read().split()
-    clientCount = (len(rawClients) - 9) / 7
+    clientCount = (len(rawClients) - 13) / 7
     x = 0
     namePosition = 9
     clientList = []


### PR DESCRIPTION
Issue reported #5 where the footer text was throwing off the count of clients. Changed to allow these additional characters to be removed to maintain an accurate count