### PR TITLE
Accommodate disable client text

### DIFF
--- a/vpnrpt.py
+++ b/vpnrpt.py
@@ -84,7 +84,7 @@ def getClientList():
     logging.debug('--> getClientList')
     rawClients = os.popen("pivpn -l").read().split()
     if vpnType == 'WireGuard':
-        clientCount = (len(rawClients) - 9) / 7
+        clientCount = (len(rawClients) - 13) / 7
         x = 0
         namePosition = 9
         clientList = []


### PR DESCRIPTION
Looks like an update added in some addition padding text meaning the client count was knocked out. Updated to exclude these additional characters